### PR TITLE
Enable client common name in openvpn-status.log instead of UNDEF

### DIFF
--- a/files/configuration/create_server_config.sh
+++ b/files/configuration/create_server_config.sh
@@ -68,6 +68,7 @@ if [ "${USE_CLIENT_CERTIFICATE}" != "true" ] ; then
 cat <<Part03 >>$CONFIG_FILE
 plugin /usr/lib64/openvpn/plugins/openvpn-plugin-auth-pam.so openvpn
 verify-client-cert optional
+username-as-common-name
 
 Part03
 


### PR DESCRIPTION
When using LDAP + OTP authentication client name in openvpn-status.log appears as UNDEF:

```
# cat openvpn-status.log 
OpenVPN CLIENT LIST
Updated,Thu Nov  1 00:50:10 2018
Common Name,Real Address,Bytes Received,Bytes Sent,Connected Since
UNDEF,xxx.xxx.xxx.xxx:55198,5902,7793,Thu Nov  1 21:10:39 2018
UNDEF,yyy.yyy.yyy.yyy:38646,5138,7013,Thu Nov  1 22:42:54 2018
…
```

In order to solve that and show client name, the following option has to bee added to config file:

`username-as-common-name`