### PR TITLE
FIX: setup_ldap.sh inporting certificate issue

### DIFF
--- a/files/configuration/setup_ldap.sh
+++ b/files/configuration/setup_ldap.sh
@@ -20,7 +20,7 @@ fi
 
 if [ "${LDAP_TLS_CA_CERT}x" != "x" ] ; then
 
- echo $LDAP_TLS_CA_CERT > $OPENVPN_DIR/ldap-ca.crt
+ echo "$LDAP_TLS_CA_CERT" > $OPENVPN_DIR/ldap-ca.crt
  echo "tls_cacertfile ${OPENVPN_DIR}/ldap-ca.crt" >> $LDAP_CONFIG
 
 fi


### PR DESCRIPTION
Dear maintainer,

This PR is fixing that the certificate is not imported properly when using `LDAP_TLS_CA_CERT` options.
it was because the shell script echo the content without `"` will lead to echo the content in single line.

docker compose example:
```
version: '3.3'

services:
   openvpn:
     cap_add:
       - NET_ADMIN
     container_name: openvpn
     image: wheelybird/openvpn-ldap-otp
     volumes:
       - /localpath/openvpn/:/etc/openvpn
     restart: always
     environment:
       OVPN_SERVER_CN: xxx
       LDAP_URI: ldap://xxx
       LDAP_BASE_DN: ou=xxx,dc=xxx,dc=xxx
       LDAP_BIND_USER_DN: cn=xxx,dc=xxx,dc=xxx
       LDAP_BIND_USER_PASS: xxx
       #LDAP_FILTER: ou=Users,dc=xxx,dc=xx
       LDAP_TLS: "true"
       LDAP_TLS_CA_CERT: |-
         -----BEGIN CERTIFICATE-----
         ...
         -----END CERTIFICATE-----
     ports:
       - "443:443"
       - "1194:1194/udp"
networks:
  default:
    external:
      name: openvpn
```