### PR TITLE
Force all traffic through VPN adapter

### DIFF
--- a/files/bin/show-client-config
+++ b/files/bin/show-client-config
@@ -26,6 +26,7 @@ auth SHA512
 comp-lzo
 proto tcp
 reneg-sec 0
+redirect-gateway def1
 "
 
 if [ "${USE_CLIENT_CERTIFICATE}" != "true" ] ; then

--- a/files/bin/show-client-config
+++ b/files/bin/show-client-config
@@ -26,8 +26,11 @@ auth SHA512
 comp-lzo
 proto tcp
 reneg-sec 0
-redirect-gateway def1
 "
+
+if [ "${OVPN_ROUTES}x" == "x" ] ; then
+ echo "redirect-gateway def1"
+fi
 
 if [ "${USE_CLIENT_CERTIFICATE}" != "true" ] ; then
  echo "auth-user-pass"


### PR DESCRIPTION
This pull requests modies the client configuration in order to force all of the client traffic through the VPN tunnel. It does so by setting the the `redirect-gateway def1` directive.

Feel free to reject this PR if this is not something that is needed, however I found it to be necessary on my system(s).