### PR TITLE
Allow manual configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Configuration is via environmental variables.  Here's a list, along with the def
  * `OVPN_ENABLE_COMPRESSION` (true): Enable this to add `comp-lzo` to the server and client configuration.  This will compress traffic going through the VPN tunnel.
  * `OVPN_IDLE_TIMEOUT` (_undefined_): The number of seconds before an idle VPN connection will be disconnected.  This also prevents the client reconnecting due to a keepalive heartbeat timeout.  You might want to use this setting for compliance reasons (e.g. PCI_DSS).  See [Keepalive settings](#Keepalive settings) for more information
  * `OVPN_VERBOSITY` (4):  The verbosity of OpenVPN's logs.
+ * `OVPN_EXTRA` (_undefined_): Additional configuration options which will be appended verbatim to the server configuration.
 
  * `OVPN_MANAGEMENT_ENABLE` (false): Enable the TCP management interface on port 5555. This service allows raw TCP and telnet connections, check [the docs](https://openvpn.net/community-resources/management-interface/) for further information. 
  * `OVPN_MANAGEMENT_NOAUTH` (false): Allow access to the management interface without any authentication. Note that this option should only be enabled if the management port is not accessible to the internet.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Configuration is via environmental variables.  Here's a list, along with the def
  * `OVPN_ENABLE_COMPRESSION` (true): Enable this to add `comp-lzo` to the server and client configuration.  This will compress traffic going through the VPN tunnel.
  * `OVPN_IDLE_TIMEOUT` (_undefined_): The number of seconds before an idle VPN connection will be disconnected.  This also prevents the client reconnecting due to a keepalive heartbeat timeout.  You might want to use this setting for compliance reasons (e.g. PCI_DSS).  See [Keepalive settings](#Keepalive settings) for more information
  * `OVPN_VERBOSITY` (4):  The verbosity of OpenVPN's logs.
+ * `OVPN_DEFAULT_SERVER` (true): If true, the OpenVPN `server <network> <netmask>` directive will be generated in the server configuration file. If `false`, you have to configure the server yourself by using `OVPN_EXTRA`.
  * `OVPN_EXTRA` (_undefined_): Additional configuration options which will be appended verbatim to the server configuration.
 
  * `OVPN_MANAGEMENT_ENABLE` (false): Enable the TCP management interface on port 5555. This service allows raw TCP and telnet connections, check [the docs](https://openvpn.net/community-resources/management-interface/) for further information. 

--- a/files/configuration/create_server_config.sh
+++ b/files/configuration/create_server_config.sh
@@ -114,3 +114,5 @@ if [ "${OVPN_MANAGEMENT_ENABLE}" == "true" ]; then
 else
   echo "openvpn: management interface disabled"
 fi
+
+echo $OVPN_EXTRA >> $CONFIG_FILE

--- a/files/configuration/create_server_config.sh
+++ b/files/configuration/create_server_config.sh
@@ -2,10 +2,13 @@ CONFIG_FILE="${OPENVPN_DIR}/server.conf"
 
 echo "openvpn: creating server config"
 
-cat <<Part01 >$CONFIG_FILE
-# OpenVPN server configuration
+echo "# OpenVPN server configuration" >> $CONFIG_FILE
 
-server $OVPN_NETWORK
+if [ "${OVPN_DEFAULT_SERVER}" == "true" ]; then
+ echo "server $OVPN_NETWORK" >> $CONFIG_FILE
+fi
+
+cat <<Part01 >$CONFIG_FILE
 
 port 1194
 proto $OVPN_PROTOCOL
@@ -115,4 +118,4 @@ else
   echo "openvpn: management interface disabled"
 fi
 
-echo $OVPN_EXTRA >> $CONFIG_FILE
+echo "$OVPN_EXTRA" >> $CONFIG_FILE

--- a/files/configuration/set_defaults.sh
+++ b/files/configuration/set_defaults.sh
@@ -43,6 +43,7 @@ if [ "${OVPN_ENABLE_COMPRESSION}x" == "x" ];      then export OVPN_ENABLE_COMPRE
 if [ "${REGENERATE_CERTS}x" == "x" ];             then export REGENERATE_CERTS="false";                   fi
 if [ "${OVPN_MANAGEMENT_ENABLE}x" == "x" ];       then export OVPN_MANAGEMENT_ENABLE="false";             fi
 if [ "${OVPN_MANAGEMENT_NOAUTH}x" == "x" ];       then export OVPN_MANAGEMENT_NOAUTH="false";             fi
+if [ "${OVPN_DEFAULT_SERVER}x" == "x" ];          then export OVPN_DEFAULT_SERVER="true";                 fi
 if [ "${DEBUG}x" == "x" ];                        then export DEBUG="false";                              fi
 if [ "${LOG_TO_STDOUT}x" == "x" ];                then export LOG_TO_STDOUT="true";                       fi
 if [ "${ENABLE_OTP}x" == "x" ];                   then export ENABLE_OTP="false";                         fi


### PR DESCRIPTION
In some cases, manual additions to the server config file may be necessary, e.g. when setting up a reverse tunnel or when building a client-to-client network.

I propose a `OVPN_EXTRA` env variable which gets appended verbatim to the server config, and a `OVPN_DEFAULT_SERVER` variable which controls whether the default `server ...` directive should be generated or not.

The default values keep the current behavior.