### PR TITLE
Allow specification of tunnel interface name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Configuration is via environmental variables.  Here's a list, along with the def
  * `OVPN_ENABLE_COMPRESSION` (true): Enable this to add `comp-lzo` to the server and client configuration.  This will compress traffic going through the VPN tunnel.
  * `OVPN_IDLE_TIMEOUT` (_undefined_): The number of seconds before an idle VPN connection will be disconnected.  This also prevents the client reconnecting due to a keepalive heartbeat timeout.  You might want to use this setting for compliance reasons (e.g. PCI_DSS).  See [Keepalive settings](#Keepalive settings) for more information
  * `OVPN_VERBOSITY` (4):  The verbosity of OpenVPN's logs.
+ * `OVPN_EXTRA` (_undefined_): Additional configuration options which will be appended verbatim to the server configuration.
 
  * `OVPN_MANAGEMENT_ENABLE` (false): Enable the TCP management interface on port 5555. This service allows raw TCP and telnet connections, check [the docs](https://openvpn.net/community-resources/management-interface/) for further information. 
  * `OVPN_MANAGEMENT_NOAUTH` (false): Allow access to the management interface without any authentication. Note that this option should only be enabled if the management port is not accessible to the internet.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Configuration is via environmental variables.  Here's a list, along with the def
  * `OVPN_ENABLE_COMPRESSION` (true): Enable this to add `comp-lzo` to the server and client configuration.  This will compress traffic going through the VPN tunnel.
  * `OVPN_IDLE_TIMEOUT` (_undefined_): The number of seconds before an idle VPN connection will be disconnected.  This also prevents the client reconnecting due to a keepalive heartbeat timeout.  You might want to use this setting for compliance reasons (e.g. PCI_DSS).  See [Keepalive settings](#Keepalive settings) for more information
  * `OVPN_VERBOSITY` (4):  The verbosity of OpenVPN's logs.
+ * `OVPN_DEFAULT_SERVER` (true): If true, the OpenVPN `server <network> <netmask>` directive will be generated in the server configuration file. If `false`, you have to configure the server yourself by using `OVPN_EXTRA`.
  * `OVPN_EXTRA` (_undefined_): Additional configuration options which will be appended verbatim to the server configuration.
 
  * `OVPN_MANAGEMENT_ENABLE` (false): Enable the TCP management interface on port 5555. This service allows raw TCP and telnet connections, check [the docs](https://openvpn.net/community-resources/management-interface/) for further information. 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Configuration is via environmental variables.  Here's a list, along with the def
 
  * `OVPN_TLS_CIPHERS` (TLS-DHE-RSA-WITH-AES-256-CBC-SHA:TLS-DHE-RSA-WITH-AES-256-CBC-SHA256:TLS-DHE-RSA-WITH-AES-256-CBC-SHA256:TLS-DHE-RSA-WITH-CAMELLIA-256-CBC-SHA:TLS-DHE-RSA-WITH-AES-128-CBC-SHA): Determines which ciphers will be set for `tls-cipher` in the openvpn config file.
  * `OVPN_PROTOCOL` (udp):  The protocol OpenVPN uses.  Either `udp` or `tcp`.
- * `OVPN_INTERFACE` (tun):  The network tunnel interface OpenVPN uses.
+ * `OVPN_INTERFACE_NAME` (tun):  The name of the network tunnel interface OpenVPN uses.
  * `OVPN_NETWORK` (10.50.50.0 255.255.255.0):  The network that will be used the the VPN in `network_address netmask` format.
  * `OVPN_ROUTES` (_undefined_):  A comma-separated list of routes that OpenVPN will push to the client, in `network_address netmask` format.  e.g. `172.16.10.0 255.255.255.0,172.17.20.0 255.255.255.0`.  If NAT isn't enabled then you'll need to ensure that destinations on the network have the return route set for the OpenVPN network.  The default is to pass all traffic through the VPN tunnel (which will also enable NAT).
  * `OVPN_NAT` (true):  If set to true then the client traffic will be masqueraded by the OpenVPN server.  This allows you to connect to targets on the other side of the tunnel without needing to add return routes to those targets (the targets will see the OpenVPN server's IP rather than the client's).

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Configuration is via environmental variables.  Here's a list, along with the def
 
  * `OVPN_TLS_CIPHERS` (TLS-DHE-RSA-WITH-AES-256-CBC-SHA:TLS-DHE-RSA-WITH-AES-256-CBC-SHA256:TLS-DHE-RSA-WITH-AES-256-CBC-SHA256:TLS-DHE-RSA-WITH-CAMELLIA-256-CBC-SHA:TLS-DHE-RSA-WITH-AES-128-CBC-SHA): Determines which ciphers will be set for `tls-cipher` in the openvpn config file.
  * `OVPN_PROTOCOL` (udp):  The protocol OpenVPN uses.  Either `udp` or `tcp`.
+ * `OVPN_INTERFACE` (tun):  The network tunnel interface OpenVPN uses.
  * `OVPN_NETWORK` (10.50.50.0 255.255.255.0):  The network that will be used the the VPN in `network_address netmask` format.
  * `OVPN_ROUTES` (_undefined_):  A comma-separated list of routes that OpenVPN will push to the client, in `network_address netmask` format.  e.g. `172.16.10.0 255.255.255.0,172.17.20.0 255.255.255.0`.  If NAT isn't enabled then you'll need to ensure that destinations on the network have the return route set for the OpenVPN network.  The default is to pass all traffic through the VPN tunnel (which will also enable NAT).
  * `OVPN_NAT` (true):  If set to true then the client traffic will be masqueraded by the OpenVPN server.  This allows you to connect to targets on the other side of the tunnel without needing to add return routes to those targets (the targets will see the OpenVPN server's IP rather than the client's).

--- a/files/configuration/create_server_config.sh
+++ b/files/configuration/create_server_config.sh
@@ -12,7 +12,7 @@ cat <<Part01 >>$CONFIG_FILE
 
 port 1194
 proto $OVPN_PROTOCOL
-dev $OVPN_INTERFACE
+dev $OVPN_INTERFACE_NAME
 dev-type tun
 
 ca $PKI_DIR/ca.crt

--- a/files/configuration/create_server_config.sh
+++ b/files/configuration/create_server_config.sh
@@ -114,3 +114,5 @@ if [ "${OVPN_MANAGEMENT_ENABLE}" == "true" ]; then
 else
   echo "openvpn: management interface disabled"
 fi
+
+echo $OVPN_EXTRA >> $CONFIG_FILE

--- a/files/configuration/create_server_config.sh
+++ b/files/configuration/create_server_config.sh
@@ -2,10 +2,13 @@ CONFIG_FILE="${OPENVPN_DIR}/server.conf"
 
 echo "openvpn: creating server config"
 
-cat <<Part01 >$CONFIG_FILE
-# OpenVPN server configuration
+echo "# OpenVPN server configuration" >> $CONFIG_FILE
 
-server $OVPN_NETWORK
+if [ "${OVPN_DEFAULT_SERVER}" == "true" ]; then
+ echo "server $OVPN_NETWORK" >> $CONFIG_FILE
+fi
+
+cat <<Part01 >$CONFIG_FILE
 
 port 1194
 proto $OVPN_PROTOCOL
@@ -115,4 +118,4 @@ else
   echo "openvpn: management interface disabled"
 fi
 
-echo $OVPN_EXTRA >> $CONFIG_FILE
+echo "$OVPN_EXTRA" >> $CONFIG_FILE

--- a/files/configuration/create_server_config.sh
+++ b/files/configuration/create_server_config.sh
@@ -2,13 +2,13 @@ CONFIG_FILE="${OPENVPN_DIR}/server.conf"
 
 echo "openvpn: creating server config"
 
-echo "# OpenVPN server configuration" >> $CONFIG_FILE
+echo "# OpenVPN server configuration" > $CONFIG_FILE
 
 if [ "${OVPN_DEFAULT_SERVER}" == "true" ]; then
  echo "server $OVPN_NETWORK" >> $CONFIG_FILE
 fi
 
-cat <<Part01 >$CONFIG_FILE
+cat <<Part01 >>$CONFIG_FILE
 
 port 1194
 proto $OVPN_PROTOCOL

--- a/files/configuration/create_server_config.sh
+++ b/files/configuration/create_server_config.sh
@@ -13,6 +13,7 @@ cat <<Part01 >>$CONFIG_FILE
 port 1194
 proto $OVPN_PROTOCOL
 dev $OVPN_INTERFACE
+dev-type tun
 
 ca $PKI_DIR/ca.crt
 cert $PKI_DIR/issued/${OVPN_SERVER_CN}.crt

--- a/files/configuration/create_server_config.sh
+++ b/files/configuration/create_server_config.sh
@@ -12,7 +12,7 @@ cat <<Part01 >>$CONFIG_FILE
 
 port 1194
 proto $OVPN_PROTOCOL
-dev tun
+dev $OVPN_INTERFACE
 
 ca $PKI_DIR/ca.crt
 cert $PKI_DIR/issued/${OVPN_SERVER_CN}.crt

--- a/files/configuration/set_defaults.sh
+++ b/files/configuration/set_defaults.sh
@@ -35,7 +35,7 @@ default_tls_ciphers="TLS-DHE-RSA-WITH-AES-256-CBC-SHA:TLS-DHE-RSA-WITH-AES-256-C
 
 if [ "${OVPN_TLS_CIPHERS}x" == "x" ];             then export OVPN_TLS_CIPHERS=$default_tls_ciphers;      fi
 if [ "${OVPN_PROTOCOL}x" == "x" ];                then export OVPN_PROTOCOL="udp";                        fi
-if [ "${OVPN_INTERFACE}x" == "x" ];               then export OVPN_INTERFACE="tun";                      fi
+if [ "${OVPN_INTERFACE_NAME}x" == "x" ];          then export OVPN_INTERFACE_NAME="tun";                  fi
 if [ "${OVPN_NETWORK}x" == "x" ];                 then export OVPN_NETWORK="10.50.50.0 255.255.255.0";    fi
 if [ "${OVPN_VERBOSITY}x" == "x" ];               then export OVPN_VERBOSITY="3";                         fi
 if [ "${OVPN_NAT}x" == "x" ];                     then export OVPN_NAT="true";                            fi

--- a/files/configuration/set_defaults.sh
+++ b/files/configuration/set_defaults.sh
@@ -43,6 +43,7 @@ if [ "${OVPN_ENABLE_COMPRESSION}x" == "x" ];      then export OVPN_ENABLE_COMPRE
 if [ "${REGENERATE_CERTS}x" == "x" ];             then export REGENERATE_CERTS="false";                   fi
 if [ "${OVPN_MANAGEMENT_ENABLE}x" == "x" ];       then export OVPN_MANAGEMENT_ENABLE="false";             fi
 if [ "${OVPN_MANAGEMENT_NOAUTH}x" == "x" ];       then export OVPN_MANAGEMENT_NOAUTH="false";             fi
+if [ "${OVPN_DEFAULT_SERVER}x" == "x" ];          then export OVPN_DEFAULT_SERVER="true";                 fi
 if [ "${DEBUG}x" == "x" ];                        then export DEBUG="false";                              fi
 if [ "${LOG_TO_STDOUT}x" == "x" ];                then export LOG_TO_STDOUT="true";                       fi
 if [ "${ENABLE_OTP}x" == "x" ];                   then export ENABLE_OTP="false";                         fi

--- a/files/configuration/set_defaults.sh
+++ b/files/configuration/set_defaults.sh
@@ -35,6 +35,7 @@ default_tls_ciphers="TLS-DHE-RSA-WITH-AES-256-CBC-SHA:TLS-DHE-RSA-WITH-AES-256-C
 
 if [ "${OVPN_TLS_CIPHERS}x" == "x" ];             then export OVPN_TLS_CIPHERS=$default_tls_ciphers;      fi
 if [ "${OVPN_PROTOCOL}x" == "x" ];                then export OVPN_PROTOCOL="udp";                        fi
+if [ "${OVPN_INTERFACE}x" == "x" ];               then export OVPN_INTERFACE="tun";                      fi
 if [ "${OVPN_NETWORK}x" == "x" ];                 then export OVPN_NETWORK="10.50.50.0 255.255.255.0";    fi
 if [ "${OVPN_VERBOSITY}x" == "x" ];               then export OVPN_VERBOSITY="3";                         fi
 if [ "${OVPN_NAT}x" == "x" ];                     then export OVPN_NAT="true";                            fi


### PR DESCRIPTION
When running multiple VPN servers on one host, they share a kernel  `tun` interface device. This leads to all kinds of problems, eg. with NAT and `iptables`.

To solve this, I added the optional `OVPN_INTERFACE` env config option (default: "tun"), which specifies the interface name (eg. tun3, mytunnel...) in order to give each instance a separate tunnel interface. This also simplifies firewall configuration.