### PR TITLE
Add option to specify additional custom iptables rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Configuration is via environmental variables.  Here's a list, along with the def
  * `OVPN_VERBOSITY` (4):  The verbosity of OpenVPN's logs.
  * `OVPN_DEFAULT_SERVER` (true): If true, the OpenVPN `server <network> <netmask>` directive will be generated in the server configuration file. If `false`, you have to configure the server yourself by using `OVPN_EXTRA`.
  * `OVPN_EXTRA` (_undefined_): Additional configuration options which will be appended verbatim to the server configuration.
+ * `IPTABLES_EXTRA_FILE` (_undefined_): Path of a file containing additional network rules which will be appended to the iptables configuration. Uses the `iptables-save` / `iptables-restore` syntax.
 
  * `OVPN_MANAGEMENT_ENABLE` (false): Enable the TCP management interface on port 5555. This service allows raw TCP and telnet connections, check [the OpenVPN documentation](https://openvpn.net/community-resources/management-interface/) for further information.
  * `OVPN_MANAGEMENT_NOAUTH` (false): Allow access to the management interface without any authentication. Note that this option should only be enabled if the management port is not accessible to the internet.

--- a/files/configuration/setup_networking.sh
+++ b/files/configuration/setup_networking.sh
@@ -55,3 +55,15 @@ else
  fi
 
 fi
+
+# Append extra iptables rules from a file if specified
+if [ "${IPTABLES_EXTRA_FILE}x" != "x" ] ; then
+
+ if [ -f "$IPTABLES_EXTRA_FILE" ]; then
+  echo "IPTABLES_EXTRA_FILE was set, appending iptables rules from $IPTABLES_EXTRA_FILE"
+  iptables-restore -nv "$IPTABLES_EXTRA_FILE"
+ else
+  echo "IPTABLES_EXTRA_FILE was set but the specified file $IPTABLES_EXTRA_FILE cannot be found!"
+ fi
+
+fi


### PR DESCRIPTION
This pull request introduces the `IPTABLES_EXTRA_FILE` environment variable, which can be used to specify the path of an iptables rules file. This file can be created manually, or produced by `iptables-save`. The rules in this file will be appended to the container iptables configuration.

I added this feature to support some exotic routing scenarios, for example exposing a port of a specific client via the VPN host:
```
*nat
-A PREROUTING -i eth0 -p tcp --dport 2222 -j DNAT --to 10.60.0.2:2222
COMMIT

*filter
-A FORWARD -p tcp -d 10.60.0.2 --dport 2222 -j ACCEPT
COMMIT
```