### PR TITLE
Implemented setting for pam_authc_search

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Configuration is via environmental variables.  Here's a list, along with the def
  * `LDAP_TLS` (false):  Changes (overrides) `LDAP_ENCRYPT_CONNECTION` to `starttls` (this setting is for backwards-compatibility with previous versions).
  * `LDAP_TLS_VALIDATE_CERT` (true):  Set to 'true' to ensure the TLS certificate can be validated.  'false' will ignore certificate issues - you might need this if you're using a self-signed certificate and not passing in the CA certificate.
  * `LDAP_TLS_CA_CERT` (_undefined_): The contents of the CA certificate file for the LDAP server.  You'll need this to enable TLS when using self-signed certificates.
+ * `LDAP_DISABLE_BIND_SEARCH` (false): Set to 'true' to stop nslcd searching for the user using their own credentials on login. By default nslcd does this as an extra verification step but some LDAP implementations disable searches for unprivileged users by default. Note that you should ensure your LDAP server handles invalid credentials properly before enabling this.
 
  * `ACTIVE_DIRECTORY_COMPAT_MODE` (false): Sets `LDAP_LOGIN_ATTRIBUTE` to `sAMAccountName` and `LDAP_FILTER` to `(objectClass=user)`, which allows LDAP lookups to work with Active Directory.  This will override any value you've manually set for those settings.
 

--- a/files/configuration/setup_ldap.sh
+++ b/files/configuration/setup_ldap.sh
@@ -55,3 +55,7 @@ if [ "${LDAP_BIND_USER_DN}x" != "x" ] ; then
   echo "bindpw $LDAP_BIND_USER_PASS" >> $LDAP_CONFIG
 fi
 
+if [ "${LDAP_DISABLE_BIND_SEARCH}" == "true" ] ; then
+  echo "pam_authc_search NONE" >> $LDAP_CONFIG
+fi
+

--- a/files/configuration/setup_ldap.sh
+++ b/files/configuration/setup_ldap.sh
@@ -56,6 +56,6 @@ if [ "${LDAP_BIND_USER_DN}x" != "x" ] ; then
 fi
 
 if [ "${LDAP_DISABLE_BIND_SEARCH}" == "true" ] ; then
-  echo "pam_authc_search NONE" >> $LDAP_CONFIG
+  echo "pam_authc_search none" >> $LDAP_CONFIG
 fi
 


### PR DESCRIPTION
Some LDAP servers don't allow unprivileged users to perform LDAP search queries by default (such as JumpCloud in our case). This adds a setting in to stop nslcd from performing a search as soon as the user's credentials are verified.