### PR TITLE
Update setup_fail2ban.sh

### DIFF
--- a/files/configuration/setup_fail2ban.sh
+++ b/files/configuration/setup_fail2ban.sh
@@ -34,5 +34,5 @@ EOF
 
 echo "Starting fail2ban..."
 touch /var/log/auth.log
-mkdir /var/run/fail2ban
+mkdir -p /var/run/fail2ban
 /usr/bin/fail2ban-server -xb --logtarget=stdout start


### PR DESCRIPTION
restart container 
mkdir: cannot create directory ‘/var/run/fail2ban : File exists 
but 
Starting fail2ban...
ERROR: While reading from '/etc/fail2ban/fail2ban.local' [line  3]: section 'Definition' already exists